### PR TITLE
Make kw compliant with XDG Base Directory Specification

### DIFF
--- a/kw
+++ b/kw
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-# Note: the following line should not be modified, and neither the token should
-# be repeated in this file because It will be replaced during installation with
-# the respective installation prefix.
-KW_INSTALL_PREFIX=${KW_INSTALL_PREFIX:-"##KW_INSTALL_PREFIX_TOKEN##"}
-
 KWORKFLOW=${KWORKFLOW:-"kw"}
+
+# Global paths
+
+# Kw shell files
+KW_LIB_DIR="${KW_LIB_DIR:-"$HOME/.local/lib"}/$KWORKFLOW"
+KW_PLUGINS_DIR="${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}"
+
+# Share files
+KW_SHARE_DIR="${XDG_DATA_HOME:-"$HOME/.local/share"}/$KWORKFLOW"
+KW_DOC_DIR="$KW_SHARE_DIR/doc"
+KW_MAN_DIR="$KW_SHARE_DIR/man"
+KW_SOUND_DIR="$KW_SHARE_DIR/sound"
+
+# User specific data files (currently this collapses with the share dir,
+# but would not for a system-wide installation)
+KW_DATA_DIR="$KW_SHARE_DIR"
+
+# Configuration files
+KW_ETC_DIR="${XDG_CONFIG_HOME:-"$HOME/.config"}/$KWORKFLOW"
+
+# Cache folder
+KW_CACHE_DIR="${XDG_CACHE_HOME:-"$HOME/.cache"}/$KWORKFLOW"
+
+# State files
+KW_STATE_DIR="${XDG_STATE_HOME:-"$HOME/.local/state"}/$KWORKFLOW"
 
 ##BEGIN-DEV-MODE##
 KW_BIN="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -13,19 +33,15 @@ KW_BASE_DIR="$(dirname "${KW_BIN}")"
 if [ -f "${KW_BASE_DIR}/src/kwlib.sh" ]; then
   # running from source directory
   KW_LIB_DIR="${KW_BASE_DIR}/src"
-  KW_INSTALL_PREFIX="${KW_BASE_DIR}"
+  # KW_DATA_DIR # use default data folder
+  KW_DOC_DIR="${KW_BASE_DIR}/documentation"
+  KW_MAN_DIR="${KW_BASE_DIR}/documentation/man"
+  KW_SOUND_DIR="${KW_BASE_DIR}/sound"
+  KW_ETC_DIR="${KW_BASE_DIR}/etc"
+  KW_PLUGINS_DIR="${KW_LIB_DIR}/plugins"
+  # KW_CACHE_DIR # use default cache folder
 fi
 ##END-DEV-MODE##
-
-# Global paths
-KW_LIB_DIR=${KW_LIB_DIR:-"$KW_INSTALL_PREFIX/lib/kw"}
-KW_SHARE_DOC_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/doc/kw/"}
-KW_SHARE_MAN_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/man"}
-KW_SHARE_SOUND_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/sound/kw"}
-KW_ETC_DIR=${KW_ETC_DIR:-"$KW_INSTALL_PREFIX/etc/kw"}
-KW_DATA_DIR=${KW_DATA_DIR:-"$HOME/.kw"}
-KW_PLUGINS_DIR=${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}
-KW_CACHE_DIR="$HOME/.cache/kw"
 
 # Export external variables required by kworkflow
 export KWORKFLOW

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,6 @@ debian_packages=(qemu git tar python3-docutils pulseaudio-utils dunst sphinx-doc
 SILENT=1
 VERBOSE=0
 FORCE=0
-PREFIX="${PREFIX:-$HOME/.local}"
 
 declare -r app_name="kw"
 
@@ -18,17 +17,16 @@ declare -r app_name="kw"
 ## Following are the install paths
 ##
 # Paths used during the installation process
-declare -r kwbinpath="$PREFIX/bin/kw"
-declare -r binpath="$PREFIX/bin"
-declare -r libdir="$PREFIX/lib/$app_name"
-declare -r sharedir="$PREFIX/share/"
-declare -r sharedocdir="$sharedir/doc"
-declare -r sharemandir="$sharedir/man"
-declare -r sharesounddir="$sharedir/sound/kw"
-declare -r etcdir="$PREFIX/etc/kw"
-# User specific data
-declare -r datadir="$HOME/.$app_name"
-declare -r cachedir="$HOME/.cache/$app_name"
+declare -r kwbinpath="$HOME/.local/bin/$app_name"
+declare -r binpath="$HOME/.local/bin"
+declare -r libdir="$HOME/.local/lib/$app_name"
+declare -r sharedir="${XDG_DATA_HOME:-"$HOME/.local/share"}/$app_name"
+declare -r docdir="$sharedir/doc"
+declare -r mandir="$sharedir/man"
+declare -r sounddir="$sharedir/sound"
+declare -r datadir="${XDG_DATA_HOME:-"$HOME/.local/share"}/$app_name"
+declare -r etcdir="${XDG_CONFIG_HOME:-"$HOME/.config"}/$app_name"
+declare -r cachedir="${XDG_CACHE_HOME:-"$HOME/.cache/$app_name"}"
 
 ##
 ## Source code references
@@ -36,8 +34,7 @@ declare -r cachedir="$HOME/.cache/$app_name"
 declare -r SRCDIR="src"
 declare -r MAN="documentation/man/"
 declare -r CONFIG_DIR="etc"
-declare -r INSTALLTO="$PREFIX"
-declare -r KW_CACHE_DIR="$HOME/.cache/$app_name"
+declare -r KW_CACHE_DIR="$cachedir"
 
 declare -r SOUNDS="sounds"
 declare -r BASH_AUTOCOMPLETE="bash_autocomplete"
@@ -162,6 +159,27 @@ function confirm_complete_removal()
   fi
 }
 
+# This function moves the folders from the old directory structure to
+# folders of the new one.
+function legacy_folders()
+{
+  local prefix="$HOME/.local"
+
+  if [[ -d "$prefix/share/doc" && -f "$prefix/share/man/kw.rst" &&
+    -d "$prefix/share/sound/kw" && -d "$prefix/etc/kw" &&
+    -d "$HOME/.kw" ]]; then
+
+    mv "$HOME/.kw" "$datadir"
+    mv "$prefix/share/doc" "$docdir"
+    mkdir -p "$mandir"
+    mv "$prefix/share/man/kw.rst" "$mandir/"
+    mv "$prefix/share/sound/kw" "$sounddir"
+    mv "$prefix/etc/kw" "$etcdir"
+    rmdir --ignore-fail-on-non-empty "$prefix/share/man" "$prefix/share/sound" \
+      "$prefix/etc"
+  fi
+}
+
 function clean_legacy()
 {
   local completely_remove="$1"
@@ -179,13 +197,13 @@ function clean_legacy()
   [[ -d "$libdir" ]] && mv "$libdir" "$trash/lib"
 
   # Remove doc dir
-  [[ -d "$sharedocdir" ]] && mv "$sharedocdir" "$trash"
+  [[ -d "$docdir" ]] && mv "$docdir" "$trash"
 
   # Remove man
-  [[ -d "$sharemandir" ]] && mv "$sharemandir" "$trash"
+  [[ -d "$mandir" ]] && mv "$mandir" "$trash"
 
   # Remove sound files
-  [[ -d "$sharesounddir" ]] && mv "$sharesounddir" "$trash/sound"
+  [[ -d "$sounddir" ]] && mv "$sounddir" "$trash/sound"
 
   # Remove etc files
   [[ -d "$etcdir" ]] && mv "$etcdir" "$trash/etc"
@@ -216,7 +234,7 @@ function setup_config_file()
 
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$config_files_path/$global_config_name"
-    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$sharesounddir,g" \
+    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$sounddir,g" \
       -e "/^#?.*/d" "$config_files_path/$global_config_name"
     ret="$?"
     if [[ "$ret" != 0 ]]; then
@@ -250,36 +268,33 @@ function synchronize_files()
   cmd_output_manager "cp $app_name $binpath" "$verbose"
   ASSERT_IF_NOT_EQ_ZERO "The command 'cp $app_name $binpath' failed" "$?"
 
-  sed -i -e "s,##KW_INSTALL_PREFIX_TOKEN##,$PREFIX,g" "$binpath/$app_name"
-  sed -i -e "/##BEGIN-DEV-MODE##/,/##END-DEV-MODE##/ d" "$binpath/$app_name"
-
   # Lib files
   mkdir -p "$libdir"
   cmd_output_manager "rsync -vr $SRCDIR/ $libdir" "$verbose"
   ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $SRCDIR $libdir' failed" "$?"
 
   # Sound files
-  mkdir -p "$sharesounddir"
-  cmd_output_manager "rsync -vr $SOUNDS/ $sharesounddir" "$verbose"
-  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $SOUNDS $sharesounddir' failed" "$?"
+  mkdir -p "$sounddir"
+  cmd_output_manager "rsync -vr $SOUNDS/ $sounddir" "$verbose"
+  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $SOUNDS $sounddir' failed" "$?"
   ## TODO: Remove me one day
   # Old kworkflow.config uses complete.wav instead of bell
-  ln -s "$sharesounddir/bell.wav" "$sharesounddir/complete.wav"
+  ln -s "$sounddir/bell.wav" "$sounddir/complete.wav"
 
   # Documentation files
-  mkdir -p "$sharedocdir"
-  cmd_output_manager "rsync -vr $DOCUMENTATION/ $sharedocdir" "$verbose"
-  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $DOCUMENTATION $sharedocdir' failed" "$?"
+  mkdir -p "$docdir"
+  cmd_output_manager "rsync -vr $DOCUMENTATION/ $docdir" "$verbose"
+  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $DOCUMENTATION $docdir' failed" "$?"
 
   # man file
-  mkdir -p "$sharemandir"
-  cmd_output_manager "rsync -vr $MAN $sharemandir" "$verbose"
-  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $DOCUMENTATION $sharemandir' failed" "$?"
+  mkdir -p "$mandir"
+  cmd_output_manager "rsync -vr $MAN $mandir" "$verbose"
+  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $DOCUMENTATION $mandir' failed" "$?"
 
   # etc files
   mkdir -p "$etcdir"
   cmd_output_manager "rsync -vr $CONFIG_DIR/ $etcdir" "$verbose"
-  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $CONFIG_DIR $INSTALLTO' failed" "$?"
+  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $CONFIG_DIR/ $etcdir $verbose' failed" "$?"
 
   # User data
   mkdir -p "$datadir"
@@ -317,7 +332,7 @@ function synchronize_files()
   say "$SEPARATOR"
   # Create ~/.cache/kw for support some of the operations
   mkdir -p "$cachedir"
-  say "$app_name installed into $PREFIX"
+  say "$app_name installed into $HOME"
   warning " -> For a better experience with kw, please, open a new terminal."
 }
 
@@ -358,6 +373,8 @@ function install_home()
   # Check Dependencies
   say "Checking dependencies ..."
   check_dependencies
+  # Move old folder structure to new one
+  legacy_folders
   # First clean old installation
   clean_legacy
   # Synchronize source files
@@ -376,10 +393,6 @@ for arg; do
   fi
   if [ "$arg" = "--force" ]; then
     FORCE=1
-    continue
-  fi
-  if [[ "$arg" =~ "--prefix=" ]]; then
-    PREFIX=${arg#*=}
     continue
   fi
   set -- "$@" "$arg"

--- a/src/help.sh
+++ b/src/help.sh
@@ -38,7 +38,7 @@ function kworkflow_help()
 # installed to the system
 function kworkflow_man()
 {
-  doc="$KW_SHARE_MAN_DIR"
+  doc="$KW_MAN_DIR"
   ret=0
 
   if ! man kw > /dev/null 2>&1; then

--- a/src/init.sh
+++ b/src/init.sh
@@ -15,7 +15,7 @@ function init_kw()
 
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$PWD/$name"
-    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SHARE_SOUND_DIR,g" -e "/^#?.*/d" \
+    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SOUND_DIR,g" -e "/^#?.*/d" \
       "$PWD/$name"
   else
     complain "No such: $config_file_template or $kw_path"

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -125,9 +125,22 @@ function parse_configuration()
 # higher level setting definitions to overwrite lower level ones.
 function load_configuration()
 {
-  parse_configuration "$KW_ETC_DIR/$CONFIG_FILENAME"
-  parse_configuration "$HOME/.kw/$CONFIG_FILENAME"
-  parse_configuration "$PWD/$CONFIG_FILENAME"
+  local -a config_dirs
+  local config_home
+
+  config_home="${XDG_CONFIG_HOME:-"$HOME/.config"}/kw"
+  read -r -d ':' -a config_dirs <<< "${XDG_CONFIG_DIRS:-"/etc/xdg"}"
+
+  # echo "pwd: $PWD, config_home: $config_home, config_dirs: $config_dirs,"
+  # echo "etc: $KW_ETC_DIR"
+
+  for folder in "$PWD" "$config_home" "${config_dirs[@]/%/"/kw"}" \
+    "$KW_ETC_DIR"; do
+    if [[ -f "$folder/$CONFIG_FILENAME" ]]; then
+      parse_configuration "$folder/$CONFIG_FILENAME"
+      return
+    fi
+  done
 }
 
 # Every time that "kw_config_loader.sh" is included, the configuration file has

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -38,8 +38,8 @@ function test_init_kw()
   assertEquals "($ID)" "$USER" "$kworkflow_content"
 
   ID=2
-  kworkflow_content=$(grep "$KW_SHARE_SOUND_DIR" -o "$path_config" | head -n 1)
-  assertEquals "($ID)" "$KW_SHARE_SOUND_DIR" "$kworkflow_content"
+  kworkflow_content=$(grep "$KW_SOUND_DIR" -o "$path_config" | head -n 1)
+  assertEquals "($ID)" "$KW_SOUND_DIR" "$kworkflow_content"
 
   ID=3
   export KW_ETC_DIR="break/on/purpose"


### PR DESCRIPTION
User customizations for kw folder should now be done with the XDG_*_HOME
environmental variables, instead of PREFIX. Also, ~/.kw is no longer
recognized as a path for a configuration file (unless it is supplied in
XDG_CONFIG_DIRS). This also fixes some problems with DEV-MODE: corrects
the paths to documentation, cache and data folders.

Closes: #296 and #385

Signed-off-by: João Seckler <jseckler@riseup.net>